### PR TITLE
Revert "Update dependency numpy to v2.2.3 - autoclosed"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
 murmurhash==1.0.12
-numpy==2.2.3
+numpy==2.0.2
 packaging==24.2
 preshed==3.0.9
 pydantic==2.10.6


### PR DESCRIPTION
Reverts iNoles/ResumeInsight#3

Python3 on Mac is 3.9.6